### PR TITLE
Testing bare metal adjustments

### DIFF
--- a/build/scripts/build-images.sh
+++ b/build/scripts/build-images.sh
@@ -190,32 +190,32 @@ do
 
 
     # modify roslin_resources.json so that cmo in production can call sing.sh (singularity wrapper)
-    case ${tool_name} in
-        pindel)
-            # pindel needs special treament since pindel container has two executables "pindel" and "pindel2vcf"
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json pindel ${tool_version} "sing.sh ${tool_name} ${tool_version} pindel"
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json pindel2vcf ${tool_version} "sing.sh ${tool_name} ${tool_version} pindel2vcf"
-            ;;
-        vardict)
-            # vardict needs special treament since vardict container has one R script and one Perl script to be exposed
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vardict ${tool_version} "sing.sh ${tool_name} ${tool_version} vardict"
-
-            # an extra space needed at the end because cmo will append either "testsomatic.R" or "var2vcf_paired.pl"
-            # and we need to make sure it's treated as an argument.
-            # e.g. sing.sh vardict 1.4.6 testsomatic.R
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vardict_bin ${tool_version} "sing.sh ${tool_name} ${tool_version} "
-            ;;
-        vcf2maf)
-            # an extra space needed at the end because cmo will append "vcf2maf.pl"
-            # e.g. sing.sh vcf2maf 1.6.12 vcf2maf.pl
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vcf2maf ${tool_version} "sing.sh ${tool_name} ${tool_version} "
-            ;;
-        roslin)
-            # do nothing
-            ;;
-        *)
-            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json ${tool_name} ${tool_version} "sing.sh ${tool_name} ${tool_version}"
-            ;;
-    esac
+#    case ${tool_name} in
+#        pindel)
+#            # pindel needs special treament since pindel container has two executables "pindel" and "pindel2vcf"
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json pindel ${tool_version} "sing.sh ${tool_name} ${tool_version} pindel"
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json pindel2vcf ${tool_version} "sing.sh ${tool_name} ${tool_version} pindel2vcf"
+#            ;;
+#        vardict)
+#            # vardict needs special treament since vardict container has one R script and one Perl script to be exposed
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vardict ${tool_version} "sing.sh ${tool_name} ${tool_version} vardict"
+#
+#            # an extra space needed at the end because cmo will append either "testsomatic.R" or "var2vcf_paired.pl"
+#            # and we need to make sure it's treated as an argument.
+#            # e.g. sing.sh vardict 1.4.6 testsomatic.R
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vardict_bin ${tool_version} "sing.sh ${tool_name} ${tool_version} "
+#            ;;
+#        vcf2maf)
+#            # an extra space needed at the end because cmo will append "vcf2maf.pl"
+#            # e.g. sing.sh vcf2maf 1.6.12 vcf2maf.pl
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json vcf2maf ${tool_version} "sing.sh ${tool_name} ${tool_version} "
+#            ;;
+#        roslin)
+#            # do nothing
+#            ;;
+#        *)
+#            python ./update_resource_def.py -f ../../setup/cwl/roslin_resources.json ${tool_name} ${tool_version} "sing.sh ${tool_name} ${tool_version}"
+#            ;;
+#    esac
 
 done

--- a/config.variant.yaml
+++ b/config.variant.yaml
@@ -16,5 +16,5 @@ dependencies:
       min: 2.0.0
       max: 2.0.0
   cmo:
-    version: 1.9.5
+    version: 1.9.7
     install-path: /ifs/work/pi/cmo_package_archive/

--- a/setup/cwl/basic-filtering.mutect/0.1.8/basic-filtering.mutect.cwl
+++ b/setup/cwl/basic-filtering.mutect/0.1.8/basic-filtering.mutect.cwl
@@ -45,11 +45,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- basic-filtering
-- 0.1.8
+- non-cmo.sh
+- --tool
+- "basic-filtering"
+- --version
+- "0.1.8"
+- --language_version
+- "default"
+- --language
+- "bash"
 - mutect
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/basic-filtering.pindel/0.1.8/basic-filtering.pindel.cwl
+++ b/setup/cwl/basic-filtering.pindel/0.1.8/basic-filtering.pindel.cwl
@@ -45,11 +45,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- basic-filtering
-- 0.1.8
+- non-cmo.sh
+- --tool
+- "basic-filtering"
+- --version
+- "0.1.8"
+- --language_version
+- "default"
+- --language
+- "bash"
 - pindel
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/basic-filtering.somaticIndelDetector/0.1.8/basic-filtering.somaticIndelDetector.cwl
+++ b/setup/cwl/basic-filtering.somaticIndelDetector/0.1.8/basic-filtering.somaticIndelDetector.cwl
@@ -45,11 +45,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- basic-filtering
-- 0.1.8
+- non-cmo.sh
+- --tool
+- "basic-filtering"
+- --version
+- "0.1.8"
+- --language_version
+- "default"
+- --language
+- "bash"
 - sid
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/basic-filtering.vardict/0.1.8/basic-filtering.vardict.cwl
+++ b/setup/cwl/basic-filtering.vardict/0.1.8/basic-filtering.vardict.cwl
@@ -45,11 +45,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- basic-filtering
-- 0.1.8
+- non-cmo.sh
+- --tool
+- "basic-filtering"
+- --version
+- "0.1.8"
+- --language_version
+- "default"
+- --language
+- "bash"
 - vardict
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/cmo-facets.doFacets/1.5.5/cmo-facets.doFacets.cwl
+++ b/setup/cwl/cmo-facets.doFacets/1.5.5/cmo-facets.doFacets.cwl
@@ -42,9 +42,15 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- facets
-- 1.5.5
+- non-cmo.sh
+- --tool
+- "facets"
+- --version
+- "1.5.5"
+- --language_version
+- "default"
+- --language
+- "python"
 - doFacets
 
 requirements:
@@ -166,7 +172,7 @@ inputs:
 
   R_lib:
     type: ['null', string]
-    default: latest
+    default: /opt/common/CentOS_6-dev/facets_lib/0.5.6/
     doc: Which version of FACETs to load into R
     inputBinding:
       prefix: --R_lib

--- a/setup/cwl/cmo-facets.doFacets/1.5.6/cmo-facets.doFacets.cwl
+++ b/setup/cwl/cmo-facets.doFacets/1.5.6/cmo-facets.doFacets.cwl
@@ -42,9 +42,15 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- facets
-- 1.5.6
+- non-cmo.sh
+- --tool
+- "facets"
+- --version
+- "1.5.6"
+- --language_version
+- "default"
+- --language
+- "python"
 - doFacets
 
 requirements:

--- a/setup/cwl/cmo-facets.doFacets/1.5.6/cmo-facets.doFacets.cwl
+++ b/setup/cwl/cmo-facets.doFacets/1.5.6/cmo-facets.doFacets.cwl
@@ -13,7 +13,7 @@ $schemas:
 doap:release:
 - class: doap:Version
   doap:name: cmo-facets.doFacets
-  doap:revision: 1.5.5
+  doap:revision: 1.5.6
 - class: doap:Version
   doap:name: cwl-wrapper
   doap:revision: 1.0.0
@@ -44,7 +44,7 @@ class: CommandLineTool
 baseCommand:
 - sing.sh
 - facets
-- 1.5.5
+- 1.5.6
 - doFacets
 
 requirements:
@@ -191,6 +191,11 @@ inputs:
     inputBinding:
       prefix: --seed
 
+  tumor_id:
+    type: ['null', string]
+    doc: Set the value for tumor id
+    inputBinding:
+      prefix: --tumor_id
 
 outputs:
   png_files:

--- a/setup/cwl/cmo-facets.geneLevel/1.5.5/cmo-facets.geneLevel.cwl
+++ b/setup/cwl/cmo-facets.geneLevel/1.5.5/cmo-facets.geneLevel.cwl
@@ -1,0 +1,86 @@
+#!/usr/bin/env cwl-runner
+
+$namespaces:
+  dct: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+  doap: http://usefulinc.com/ns/doap#
+
+$schemas:
+- http://dublincore.org/2012/06/14/dcterms.rdf
+- http://xmlns.com/foaf/spec/20140114.rdf
+- http://usefulinc.com/ns/doap#
+
+doap:release:
+- class: doap:Version
+  doap:name: cmo-facets.geneLevel
+  doap:revision: 1.5.5
+- class: doap:Version
+  doap:name: cwl-wrapper
+  doap:revision: 1.0.0
+
+dct:creator:
+- class: foaf:Organization
+  foaf:name: Memorial Sloan Kettering Cancer Center
+  foaf:member:
+  - class: foaf:Person
+    foaf:name: Cyriac Kandoth
+    foaf:mbox: mailto:kandothc@mskcc.org
+
+dct:contributor:
+- class: foaf:Organization
+  foaf:name: Memorial Sloan Kettering Cancer Center
+  foaf:member:
+  - class: foaf:Person
+    foaf:name: Cyriac Kandoth
+    foaf:mbox: mailto:kandothc@mskcc.org
+
+cwlVersion: cwl:v1.0
+
+class: CommandLineTool
+baseCommand:
+- sing.sh
+- facets
+- 1.5.5
+- geneLevel
+
+requirements:
+  InlineJavascriptRequirement: {}
+  ResourceRequirement:
+    ramMin: 7
+    coresMin: 1
+
+doc: |
+  Generate gene-level somatic CNA calls, given the .cncf.txt file from a run of doFACETS
+
+inputs:
+  filenames:
+    type: string
+    doc: File(s) to be processed
+    inputBinding:
+      prefix: --filenames
+
+  outfile:
+    type: File
+    doc: Output filename
+    inputBinding:
+      prefix: --outfile
+
+  targetFile:
+    type: string
+    default: "IMPACT468"
+    doc: IMPACT341/410/468, or a Picard interval list file of gene target coordinates
+    inputBinding:
+      prefix: --targetFile
+
+
+outputs:
+  outfile:
+    type: File
+    outputBinding:
+      glob: |
+        ${
+          if (inputs.outfile)
+            return inputs.outfile;
+          else
+            return inputs.filenames.basename.replace(".txt", ".cna.txt");
+        }

--- a/setup/cwl/cmo-index/1.0.0/cmo-index.cwl
+++ b/setup/cwl/cmo-index/1.0.0/cmo-index.cwl
@@ -43,7 +43,7 @@ baseCommand:
 - "2.9"
 requirements:
   ResourceRequirement:
-    ramMin: 2
+    ramMin: 10
     coresMin: 1
 
 inputs:

--- a/setup/cwl/cmo-mutect/1.1.4/cmo-mutect.cwl
+++ b/setup/cwl/cmo-mutect/1.1.4/cmo-mutect.cwl
@@ -44,7 +44,9 @@ class: CommandLineTool
 baseCommand:
 - cmo_mutect
 - --version
-- 1.1.4
+- "1.1.4"
+- --java-version
+- "jdk1.6.0_45"
 
 requirements:
   InlineJavascriptRequirement: {}

--- a/setup/cwl/cmo-ppflag-fixer/0.1.1/cmo-ppflag-fixer.cwl
+++ b/setup/cwl/cmo-ppflag-fixer/0.1.1/cmo-ppflag-fixer.cwl
@@ -42,11 +42,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- htstools
-- 0.1.1
+- non-cmo.sh
+- --tool
+- "htstools"
+- --version
+- "0.1.1"
+- --language_version
+- "default"
+- --language
+- "bash"
 - ppflag-fixer
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/cmo-snp-pileup/0.1.1/cmo-snp-pileup.cwl
+++ b/setup/cwl/cmo-snp-pileup/0.1.1/cmo-snp-pileup.cwl
@@ -45,11 +45,16 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- htstools
-- 0.1.1
+- non-cmo.sh
+- --tool
+- "htstools"
+- --version
+- "0.1.1"
+- --language_version
+- "default"
+- --language
+- "bash"
 - snp-pileup
-
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/cmo-vcf2maf/1.6.12/cmo-vcf2maf.cwl
+++ b/setup/cwl/cmo-vcf2maf/1.6.12/cmo-vcf2maf.cwl
@@ -141,7 +141,7 @@ inputs:
 
   custom_enst:
     type: ['null', string]
-    default: /usr/bin/vcf2maf/data/isoform_overrides_at_mskcc
+    default: /opt/common/CentOS_6-dev/vcf2maf/v1.6.12/data/isoform_overrides_at_mskcc
     doc: List of custom ENST IDs that override canonical selection
     inputBinding:
       prefix: --custom-enst
@@ -155,7 +155,7 @@ inputs:
 
   vep_path:
     type: ['null', string]
-    default: /usr/bin/vep/
+    default: /opt/common/CentOS_6-dev/vep/v86/
     doc: Folder containing variant_effect_predictor.pl
     inputBinding:
       prefix: --vep-path

--- a/setup/cwl/cmo-vcf2maf/1.6.14/cmo-vcf2maf.cwl
+++ b/setup/cwl/cmo-vcf2maf/1.6.14/cmo-vcf2maf.cwl
@@ -150,7 +150,7 @@ inputs:
 
   custom_enst:
     type: ['null', string]
-    default: /usr/bin/vcf2maf/data/isoform_overrides_at_mskcc
+    default: /opt/common/CentOS_6-dev/vcf2maf/v1.6.12/data/isoform_overrides_at_mskcc
     doc: List of custom ENST IDs that override canonical selection
     inputBinding:
       prefix: --custom-enst
@@ -164,7 +164,7 @@ inputs:
 
   vep_path:
     type: ['null', string]
-    default: /usr/bin/vep/
+    default: /opt/common/CentOS_6-dev/vep/v86/
     doc: Folder containing variant_effect_predictor.pl
     inputBinding:
       prefix: --vep-path

--- a/setup/cwl/cmo-vcf2maf/1.6.15/cmo-vcf2maf.cwl
+++ b/setup/cwl/cmo-vcf2maf/1.6.15/cmo-vcf2maf.cwl
@@ -150,7 +150,7 @@ inputs:
 
   custom_enst:
     type: ['null', string]
-    default: /usr/bin/vcf2maf/data/isoform_overrides_at_mskcc
+    default: /opt/common/CentOS_6-dev/vcf2maf/v1.6.12/data/isoform_overrides_at_mskcc
     doc: List of custom ENST IDs that override canonical selection
     inputBinding:
       prefix: --custom-enst
@@ -164,7 +164,7 @@ inputs:
 
   vep_path:
     type: ['null', string]
-    default: /usr/bin/vep/
+    default: /opt/common/CentOS_6-dev/vep/v86/
     doc: Folder containing variant_effect_predictor.pl
     inputBinding:
       prefix: --vep-path

--- a/setup/cwl/facets.cwl
+++ b/setup/cwl/facets.cwl
@@ -48,6 +48,8 @@ inputs:
 
     normal_bam: File
     tumor_bam: File
+    tumor_sample_name: string
+    normal_sample_name: string
     genome: string
 
 outputs:
@@ -103,5 +105,6 @@ steps:
         default: 100
       cval:
         default: 50
+      tumor_id: tumor_sample_name
     out: [png_files, txt_files, out_files, rdata_files, seg_files]
-    run: cmo-facets.doFacets/1.5.5/cmo-facets.doFacets.cwl
+    run: cmo-facets.doFacets/1.5.6/cmo-facets.doFacets.cwl

--- a/setup/cwl/facets.cwl
+++ b/setup/cwl/facets.cwl
@@ -48,8 +48,7 @@ inputs:
 
     normal_bam: File
     tumor_bam: File
-    tumor_sample_name: string
-    normal_sample_name: string
+    tumor_sample_name: string 
     genome: string
 
 outputs:

--- a/setup/cwl/module-3.cwl
+++ b/setup/cwl/module-3.cwl
@@ -176,6 +176,7 @@ steps:
                     in:
                         normal_bam: normal_bam
                         tumor_bam: tumor_bam
+                        tumor_id: tumor_sample_name 
                         genome: genome
                     out: [facets_png_output, facets_txt_output, facets_out_output, facets_rdata_output, facets_seg_output]
                 pindel:

--- a/setup/cwl/module-3.cwl
+++ b/setup/cwl/module-3.cwl
@@ -176,7 +176,7 @@ steps:
                     in:
                         normal_bam: normal_bam
                         tumor_bam: tumor_bam
-                        tumor_id: tumor_sample_name 
+                        tumor_sample_name: tumor_sample_name 
                         genome: genome
                     out: [facets_png_output, facets_txt_output, facets_out_output, facets_rdata_output, facets_seg_output]
                 pindel:

--- a/setup/cwl/ngs-filters/1.2/ngs-filters.cwl
+++ b/setup/cwl/ngs-filters/1.2/ngs-filters.cwl
@@ -42,10 +42,15 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- ngs-filters
+- non-cmo.sh
+- --tool
+- "ngs-filters"
+- --version
 - "1.2"
-
+- --language_version
+- "default"
+- --language
+- "python"
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/remove-variants/0.1.1/remove-variants.cwl
+++ b/setup/cwl/remove-variants/0.1.1/remove-variants.cwl
@@ -45,10 +45,15 @@ cwlVersion: cwl:v1.0
 
 class: CommandLineTool
 baseCommand:
-- sing.sh
-- remove-variants
-- 0.1.1
-
+- non-cmo.sh
+- --tool
+- "remove-variants"
+- --version
+- "0.1.1"
+- --language_version
+- "default"
+- --language
+- "python"
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:

--- a/setup/cwl/roslin_resources.json
+++ b/setup/cwl/roslin_resources.json
@@ -179,8 +179,9 @@
             "0.7.7": "/opt/common/CentOS_6-dev/delly/0.7.7/delly", 
             "default": "/opt/common/CentOS_6-dev/delly/0.7.7/delly"
         }, 
-        "facets": {
-            "1.5.5": "/opt/common/CentOS_6-dev/FACETS/1.5.5/facets"
+        "facets": {  
+            "1.5.5": "/opt/common/CentOS_6-dev/FACETS/1.5.5/facets",
+            "1.5.6": "/opt/common/CentOS_6-dev/FACETS/1.5.6/facets" 
         }, 
         "facets_lib": {
             "0.3.22": "/opt/common/CentOS_6-dev/facets_lib/0.3.22/", 

--- a/setup/cwl/roslin_resources.json
+++ b/setup/cwl/roslin_resources.json
@@ -138,37 +138,27 @@
             "default": "/opt/common/CentOS_6-dev/R/R-3.2.2/bin/"
         }, 
         "abra": {
-            "0.92": "sing.sh abra 0.92", 
-            "2.07": "sing.sh abra 2.07", 
-            "2.08": "sing.sh abra 2.08", 
-            "2.12": "sing.sh abra 2.12", 
-            "default": "sing.sh abra 0.92"
+            "2.12": "/opt/common/CentOS_6-dev/abra/2.12/abra2-2.12.jar", 
+            "default": "/opt/common/CentOS_6-dev/abra/2.12/abra2-2.12.jar"
         }, 
         "analyzeFingerprint": {
             "default": "/opt/common/CentOS_6-dev/qc/default/analyzeFingerprint.py"
         }, 
         "basic-filtering": {
-            "0.1.6": "sing.sh basic-filtering 0.1.6", 
-            "0.1.7": "sing.sh basic-filtering 0.1.7", 
-            "0.1.8": "sing.sh basic-filtering 0.1.8", 
-            "default": "sing.sh basic-filtering 0.1.6"
+            "0.1.8": "/opt/common/CentOS_6-dev/basicfiltering/v0.1.8/runScript.sh", 
+            "default": "/opt/common/CentOS_6-dev/basicfiltering/v0.1.8/runScript.sh"
         }, 
         "bcftools": {
-            "1.3.1": "sing.sh bcftools 1.3.1", 
-            "1.5": "sing.sh bcftools 1.5", 
-            "default": "sing.sh bcftools 1.3.1"
+            "1.3.1": "/opt/common/CentOS_6-dev/bcftools/bcftools-1.3.1/bcftools", 
+            "default": "/opt/common/CentOS_6-dev/bcftools/bcftools-1.3.1/bcftools"
         }, 
         "bedtools": {
             "2.22.0": "/opt/common/CentOS_6/bedtools/bedtools-2.22.0/bin/", 
             "default": "/opt/common/CentOS_6/bedtools/bedtools-2.22.0/bin/"
         }, 
         "bwa": {
-            "0.7.12": "sing.sh bwa 0.7.12", 
-            "0.7.15": "sing.sh bwa 0.7.15", 
-            "0.7.5a": "sing.sh bwa 0.7.5a", 
-            "0.7.5a.test": "sing.sh bwa 0.7.5a.test", 
-            "0.7.5a.ubuntu": "sing.sh bwa 0.7.5a.ubuntu", 
-            "default": "sing.sh bwa 0.7.5a"
+            "0.7.5a": "/opt/common/CentOS_6/bwa/bwa-0.7.5a/bwa", 
+            "default": "/opt/common/CentOS_6/bwa/bwa-0.7.5a/bwa"
         }, 
         "convertqualityscore": {
             "1.1.8": "/opt/common/CentOS_6-dev/ConvertQualityScore/default/ConvertQualityScore", 
@@ -186,11 +176,11 @@
             "default": "/opt/common/CentOS_6-dev/qc/default/mergeCutAdaptStats.py"
         }, 
         "delly": {
-            "0.7.7": "sing.sh delly 0.7.7", 
-            "default": "sing.sh delly 0.7.7"
+            "0.7.7": "/opt/common/CentOS_6-dev/delly/0.7.7/delly", 
+            "default": "/opt/common/CentOS_6-dev/delly/0.7.7/delly"
         }, 
         "facets": {
-            "1.5.5": "sing.sh facets 1.5.5"
+            "1.5.5": "/opt/common/CentOS_6-dev/FACETS/1.5.5/facets"
         }, 
         "facets_lib": {
             "0.3.22": "/opt/common/CentOS_6-dev/facets_lib/0.3.22/", 
@@ -204,9 +194,8 @@
             "default": "/opt/common/CentOS_6-dev/facets_lib/0.3.7/"
         }, 
         "gatk": {
-            "2.3-9": "sing.sh gatk 2.3-9", 
-            "3.3-0": "sing.sh gatk 3.3-0", 
-            "default": "sing.sh gatk 3.3-0"
+            "3.3-0": "/opt/common/CentOS_6/gatk/GenomeAnalysisTK-3.3-0/GenomeAnalysisTK.jar", 
+            "default": "/opt/common/CentOS_6/gatk/GenomeAnalysisTK-3.3-0/GenomeAnalysisTK.jar"
         }, 
         "gdc-client": {
             "1.1.0": "/opt/common/CentOS_6-dev/python/python-2.7.10/bin/gdc-client", 
@@ -217,8 +206,8 @@
             "default": "/opt/common/CentOS_6-dev/getbasecounts/1.4.0/GetBaseCounts"
         }, 
         "getbasecountsmultisample": {
-            "1.2.1": "sing.sh getbasecountsmultisample 1.2.1", 
-            "default": "sing.sh getbasecountsmultisample 1.2.1"
+            "1.2.1": "/opt/common/CentOS_6-dev/getbasecountsmultisample/v1.2.1/GetBaseCountsMultiSample", 
+            "default": "/opt/common/CentOS_6-dev/getbasecountsmultisample/v1.2.1/GetBaseCountsMultiSample"
         }, 
         "hotspot3d": {
             "0.4": "/opt/common/CentOS_6-dev/hotspot3d/0.4/", 
@@ -228,25 +217,21 @@
             "0.6.1": "/opt/common/CentOS_6-dev/hotspots/0.6.1/", 
             "default": "/opt/common/CentOS_6-dev/hotspots/0.6.1/"
         }, 
-        "htstools": {
-            "0.1.1": "sing.sh htstools 0.1.1", 
-            "default": "sing.sh htstools 0.1.1"
-        }, 
         "java": {
-            "default": "sing-java.sh", 
-            "jdk1.7.0_75": "sing-java.sh", 
-            "jdk1.8.0_25": "sing-java.sh", 
-            "jdk1.8.0_31": "sing-java.sh", 
-            "jre1.7.0_75": "sing-java.sh"
+            "default": "/opt/common/CentOS_6/java/jdk1.8.0_31/bin/java", 
+            "jdk1.6.0_45": "/opt/common/CentOS_6/java/jdk1.6.0_45/bin/java", 
+            "jdk1.7.0_75": "/opt/common/CentOS_6/java/jdk1.7.0_75/bin/java", 
+            "jdk1.8.0_25": "/opt/common/CentOS_6/java/jdk1.8.0_25/bin/java", 
+            "jdk1.8.0_31": "/opt/common/CentOS_6/java/jdk1.8.0_31/bin/java", 
+            "jre1.7.0_75": "/opt/common/CentOS_6/java/jre1.7.0_75/bin/java"
         }, 
         "kallisto": {
             "0.42.1": "/opt/common/CentOS_6/kallisto/kallisto_linux-v0.42.1/kallisto", 
             "default": "/opt/common/CentOS_6/kallisto/kallisto_linux-v0.42.1/kallisto"
         }, 
         "list2bed": {
-            "1.0.0": "sing.sh list2bed 1.0.0", 
-            "1.0.1": "sing.sh list2bed 1.0.1", 
-            "default": "sing.sh list2bed 1.0.1"
+            "1.0.1": "/opt/common/CentOS_6-dev/list2bed/1.0.1/list2bed.py", 
+            "default": "/opt/common/CentOS_6-dev/list2bed/1.0.1/list2bed.py"
         }, 
         "matlab": {
             "R2014b": "/opt/common/CentOS_6-dev/matlab/R2014b/", 
@@ -259,33 +244,27 @@
             "default": "/opt/common/CentOS_6-dev/qc/default/mergePicardMetrics.pl"
         }, 
         "mutect": {
-            "1.1.4": "sing.sh mutect 1.1.4", 
-            "1.1.5": "sing.sh mutect 1.1.5"
+            "1.1.4": "/opt/common/CentOS_6-dev/mutect/v1.1.4/mutect.jar"
         }, 
         "mutsig-cv": {
             "1.4": "/opt/common/CentOS_6-dev/mutsig/cv-1.4", 
             "default": "/opt/common/CentOS_6-dev/mutsig/cv-1.4"
         }, 
         "ngs-filters": {
-            "1.1.4": "sing.sh ngs-filters 1.1.4"
+            "1.2": "/opt/common/CentOS_6-dev/ngs-filters/v1.2/run_ngs-filters.py"
         }, 
         "perl": {
-            "default": "sing-perl.sh"
+            "default": "/opt/common/CentOS_6-dev/perl/perl-5.22.0/bin/perl"
         }, 
         "picard": {
-            "1.129": "sing.sh picard 1.129", 
-            "1.96": "sing.sh picard 1.96", 
-            "2.13": "sing.sh picard 2.13",            
-            "2.9": "sing.sh picard 2.9",
-            "default": "sing.sh picard 1.96"
+            "2.9": "/opt/common/CentOS_6/picard/picard-2.9.0-jar/picard.jar", 
+            "default": "/opt/common/CentOS_6/picard/picard-2.9.0-jar/picard.jar"
         }, 
         "pindel": {
-            "0.2.5a7": "sing.sh pindel 0.2.5a7 pindel", 
-            "0.2.5b8": "sing.sh pindel 0.2.5b8 pindel"
+            "0.2.5b8": "/opt/common/CentOS_6-dev/pindel/v0.2.5b8/pindel"
         }, 
         "pindel2vcf": {
-            "0.2.5a7": "sing.sh pindel 0.2.5a7 pindel2vcf", 
-            "0.2.5b8": "sing.sh pindel 0.2.5b8 pindel2vcf"
+            "0.2.5b8": "/opt/common/CentOS_6-dev/pindel/v0.2.5b8/pindel2vcf"
         }, 
         "postprocess": {
             "1.3.1": "/opt/common/CentOS_6-dev/postprocess/1.3.1", 
@@ -296,13 +275,16 @@
         }, 
         "python": {
             "default": "/opt/common/CentOS_6-dev/python/python-2.7.10/bin/python"
-        }, 
+        },
+        "bash": {
+            "default": "/bin/bash"
+        },
         "qc": {
             "default": "/opt/common/CentOS_6-dev/qc/default"
         }, 
         "remove-variants": {
-            "0.1.1": "sing.sh remove-variants 0.1.1", 
-            "default": "sing.sh remove-variants 0.1.1"
+            "0.1.1": "/opt/common/CentOS_6-dev/remove_variants/v0.1.1/remove_variants.py", 
+            "default": "/opt/common/CentOS_6-dev/remove_variants/v0.1.1/remove_variants.py"
         }, 
         "replace-allele-counts": {
             "0.1.0": "sing.sh replace-allele-counts 0.1.0", 
@@ -311,11 +293,8 @@
             "default": "sing.sh replace-allele-counts 0.1.0"
         }, 
         "roslin-qc": {
-            "0.5.0": "sing.sh roslin-qc 0.5.0", 
-            "0.5.5": "sing.sh roslin-qc 0.5.5", 
-            "0.5.8": "sing.sh roslin-qc 0.5.8", 
-            "0.5.9": "sing.sh roslin-qc 0.5.9", 
-            "default": "sing.sh roslin-qc 0.5.8"
+            "0.5.9": "/opt/common/CentOS_6-dev/roslin-qc/v0.5.9/generate_pdf.py", 
+            "default": "/opt/common/CentOS_6-dev/roslin-qc/v0.5.9/generate_pdf.py"
         }, 
         "samstat": {
             "1.5.1": "/opt/common/CentOS_6-dev/samstat/1.5.1/samstat", 
@@ -325,9 +304,12 @@
             "0.1.19": "/opt/common/CentOS_6-dev/samtools/samtools-0.1.19/samtools", 
             "1.2": "/opt/common/CentOS_6-dev/samtools/samtools-1.2/samtools", 
             "1.3": "/opt/common/CentOS_6-dev/samtools/samtools-1.3/samtools", 
-            "1.3.1": "sing.sh samtools 1.3.1", 
-            "default": "sing.sh samtools 1.3.1"
-        }, 
+            "1.3.1": "/opt/common/CentOS_6-dev/samtools/samtools-1.3.1/samtools", 
+            "default": "/opt/common/CentOS_6-dev/samtools/samtools-1.3.1/samtools"
+        },
+        "htstools":{
+            "0.1.1": "/opt/common/CentOS_6-dev/htstools/v0.1.1/runScript.sh"
+        },
         "seq-cna": {
             "1.0.0": "sing.sh seq-cna 1.0.0"
         }, 
@@ -342,19 +324,16 @@
             "default": "/opt/common/CentOS_6/star/STAR-STAR_2.4.1d/bin/Linux_x86_64/STAR"
         }, 
         "trimgalore": {
-            "0.2.5.mod": "sing.sh trimgalore 0.2.5.mod", 
-            "0.4.3": "sing.sh trimgalore 0.4.3", 
-            "default": "sing.sh trimgalore 0.2.5.mod"
+            "0.2.5.mod": "/opt/common/CentOS_6/trim_galore/Trim_Galore_v0.2.5_MOD/trim_galore", 
+            "default": "/opt/common/CentOS_6/trim_galore/Trim_Galore_v0.2.5_MOD/trim_galore"
         }, 
         "vardict": {
-            "1.4.6": "sing.sh vardict 1.4.6 vardict", 
-            "1.5.1": "sing.sh vardict 1.5.1 vardict", 
-            "default": "sing.sh vardict 1.4.6 vardict"
+            "1.5.1": "/opt/common/CentOS_6-dev/vardict/v1.5.1/bin/VarDict", 
+            "default": "/opt/common/CentOS_6-dev/vardict/v1.5.1/bin/VarDict"
         }, 
         "vardict_bin": {
-            "1.4.6": "sing.sh vardict 1.4.6 ", 
-            "1.5.1": "sing.sh vardict 1.5.1 ", 
-            "default": "sing.sh vardict 1.4.6 "
+            "1.5.1": "/opt/common/CentOS_6-dev/vardict/v1.5.1/vardict_328e00a/", 
+            "default": "/opt/common/CentOS_6-dev/vardict/v1.5.1/vardict_328e00a/"
         }, 
         "varscan": {
             "2.3.9": "/opt/common/CentOS_6-dev/varscan/v2.3.9/VarScan.v2.3.9.jar", 
@@ -362,14 +341,13 @@
             "default": "/opt/common/CentOS_6-dev/varscan/v2.4.1/VarScan.v2.4.1.jar"
         }, 
         "vcf2maf": {
-            "1.6.12": "sing.sh vcf2maf 1.6.12 ", 
-            "1.6.14": "sing.sh vcf2maf 1.6.14 ", 
-            "1.6.15": "sing.sh vcf2maf 1.6.15 ",
-            "default": "sing.sh vcf2maf 1.6.12 "
+            "1.6.12": "/opt/common/CentOS_6-dev/vcf2maf/v1.6.12/", 
+            "1.6.15":"/opt/common/CentOS_6-dev/vcf2maf/v1.6.15/",
+            "default": "/opt/common/CentOS_6-dev/vcf2maf/v1.6.12/"
         }, 
         "vep": {
-            "86": "sing.sh vep 86", 
-            "default": "sing.sh vep 86"
+            "86": "/opt/common/CentOS_6-dev/vep/v86/", 
+            "default": "/opt/common/CentOS_6-dev/vep/v86/"
         }, 
         "vt": {
             "0.57": "/opt/common/CentOS_6-dev/vt/vt-0.57/vt", 
@@ -377,7 +355,7 @@
             "default": "/opt/common/CentOS_6-dev/vt/vt-0.5772/vt", 
             "master": "/opt/common/CentOS_6-dev/vt/master/vt"
         }
-    }, 
+    },
     "targets": {
         "AgilentExon_51MB_b37_v3": {
             "FP_genotypes": "/ifs/depot/pi/resources/targets/AgilentExon_51MB_b37_v3/FP_genotypes/AgilentExon_51MB_b37_v3_FP_tiling_genotypes.txt", 


### PR DESCRIPTION
Merged lots of changes:

- The core submodule was updated with changes from bare metal (non-cmo.sh, roslin_cacher.py) and from previous dev updates I made (roslin_request_to_yaml.py). 
- roslin_resources.json was updated to reflect changes made to "programs" field, based on bare metal requirements.
- Added 1.5.6 for cmo-facets.doFacets and cmo-facets.geneLevel (currently unused)
- Multiple adjustments to cwls (for example, added java versioning parameters for mutect; non-cmo.sh calls to account for bare metal)
- Probably a couple other things I'm missing. 

SUBSTANTIAL UPDATE, WOULD BE GREAT IF IT WORKED THE FIRST TIME